### PR TITLE
Numpy type deprecation

### DIFF
--- a/pymannkendall/pymannkendall.py
+++ b/pymannkendall/pymannkendall.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 # Supporting Functions
 # Data Preprocessing
 def __preprocessing(x):
-    x = np.asarray(x).astype(np.float)
+    x = np.asarray(x).astype(float)
     dim = x.ndim
     
     if dim == 1:


### PR DESCRIPTION
`np.float` is a deprecated alias for the builtin `float`. I am getting a warning, so I just wanted to inform you about that.
For more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations