### PR TITLE
Update pymannkendall.py

### DIFF
--- a/pymannkendall/pymannkendall.py
+++ b/pymannkendall/pymannkendall.py
@@ -299,11 +299,9 @@ def hamed_rao_modification_test(x_old, alpha = 0.05, lag=None):
     # detrending
     # x_detrend = x - np.multiply(range(1,n+1), np.median(x))
     slope, intercept = sens_slope(x_old)
-    x_detrend = x - np.arange(1,n+1) * slope
-    I = rankdata(x_detrend)
-    
+	
     # account for autocorrelation
-    acf_1 = __acf(I, nlags=lag-1)
+    acf_1 = __acf(x, nlags=lag-1)
     interval = norm.ppf(1 - alpha / 2) / np.sqrt(n)
     upper_bound = 0 + interval
     lower_bound = 0 - interval


### PR DESCRIPTION
In the 'hamed_rao_modification_test' function, there was an error in inputting I (rankdata of x_detrend, obtained by detrending the original time series, x) while calculating the autocorrelation function. The correction involves using the original time series as input for acf_1 = __acf(x, nlags=lag-1), while removing the unnecessary calculation of x_detrended and I, which are not utilized in the function.

This adjustment addresses the reported issue of NaN errors encountered by other users when utilizing the 'hamed_rao_modification_test' function.

Note: Autocorrelation needs to be assessed in the original time series rather than the detrended time series.